### PR TITLE
Patch path.py change

### DIFF
--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -9,7 +9,7 @@ import sys
 
 from charmhelpers.core import hookenv, host
 from charmhelpers import fetch
-from path import path
+from path import Path as path
 
 
 hooks = hookenv.Hooks()


### PR DESCRIPTION
path.py recently updated their defaults to deprecate the lower-case
syntax import

`from path import path`

It should now reflect the module name as a capitol

`from path import Path`

This particular patch is a bit of a hack as it imports Path as path,
retaining the old behavior, but required fewer lines of code to be
edited.